### PR TITLE
Improve entrypoint & server.xml

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -62,6 +62,7 @@ echo "hallo"
 ###  Generate SSL certificate
 # Remove current keystore
 rm -f $INSTALL/confluence/.keystore
+rm -f $INSTALL/atlassian-confluence.keystore
 
 # Generate random password for private key
 keystorePassword=$(openssl rand 16 | base64)

--- a/files/server.xml
+++ b/files/server.xml
@@ -15,7 +15,7 @@
        <Connector port="PlaceholderAppHTTPSPort" protocol="org.apache.coyote.http11.Http11NioProtocol"
            maxThreads="150" SSLEnabled="true" scheme="https" secure="true"
            clientAuth="false" sslProtocol="TLS" sslImplementationName="org.apache.tomcat.util.net.jsse.JSSEImplementation" 
-           keyAlias="localhost" keystoreFile="${catalina.home}/atlassian-jira/.keystore"
+           keyAlias="localhost" keystoreFile="${catalina.home}/atlassian-confluence.keystore"
            keystorePass="Def12345" relaxedPathChars="[]|" relaxedQueryChars="[]|{}^&#x5c;&#x60;&quot;&lt;&gt;" />
 
 

--- a/files/server.xml
+++ b/files/server.xml
@@ -25,7 +25,7 @@
         <Engine name="Catalina" defaultHost="localhost">
             <Host name="localhost" appBase="webapps" unpackWARs="true" autoDeploy="true">
 
-                <Context path="" docBase="${catalina.home}/atlassian-jira" reloadable="false" useHttpOnly="true">
+                <Context path="" docBase="../confluence" reloadable="false" useHttpOnly="true">
                     <Resource name="UserTransaction" auth="Container" type="javax.transaction.UserTransaction"
                               factory="org.objectweb.jotm.UserTransactionFactory" jotm.timeout="60"/>
                     <Manager pathname=""/>


### PR DESCRIPTION
The change in the entrypoint removes the new generates ssl cert if exist ( necessary if the container restarts )

First change in the server.xml define the correct path to the ssl cert.
Second change set the correct path to the docBase.